### PR TITLE
Support using a connectionstring name for config.

### DIFF
--- a/src/NLog.Targets.ElasticSearch/NLog.Targets.ElasticSearch.csproj
+++ b/src/NLog.Targets.ElasticSearch/NLog.Targets.ElasticSearch.csproj
@@ -37,6 +37,7 @@
       <HintPath>..\packages\NLog.3.1.0.0\lib\net40\NLog.dll</HintPath>
     </Reference>
     <Reference Include="System" />
+    <Reference Include="System.configuration" />
     <Reference Include="System.Core" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />


### PR DESCRIPTION
Convert the Exception object to a string so that it doesn't break when being serialized by SimpleJson.
Only add fields if they render non empty values.
Change default index name to match the official logstash format.
Add some error handling.