### PR TITLE
Change to use static connection pool and allow more than 1 host in the connection string.

### DIFF
--- a/src/NLog.Targets.ElasticSearch/ElasticSearchTarget.cs
+++ b/src/NLog.Targets.ElasticSearch/ElasticSearchTarget.cs
@@ -48,8 +48,8 @@ namespace NLog.Targets.ElasticSearch
             if (!String.IsNullOrEmpty(ConnectionName))
                 connectionStringSettings = ConfigurationManager.ConnectionStrings[ConnectionName];
 
-            var node = connectionStringSettings != null ? new Uri(connectionStringSettings.ConnectionString) : new Uri(string.Format("http://{0}:{1}", Host, Port));
-            var connectionPool = new SniffingConnectionPool(new[] { node });
+            var nodes = connectionStringSettings != null ? connectionStringSettings.ConnectionString.Split(',').Select(url => new Uri(url)) : new[] { new Uri(string.Format("http://{0}:{1}", Host, Port)) };
+            var connectionPool = new StaticConnectionPool(nodes);
             var config = new ConnectionConfiguration(connectionPool);
             _client = new ElasticsearchClient(config);
         }


### PR DESCRIPTION
I've been talking to a guy on the ElasticSearch dev team and they don't recommend using the sniffing connection pool unless you have a really large deployment of unknown nodes. We have also been having some problems with it.