### PR TITLE
Decrease Bulk() method CPU usage by 70% by not deserializing the response

### DIFF
--- a/src/NLog.Targets.ElasticSearch/ElasticSearchTarget.cs
+++ b/src/NLog.Targets.ElasticSearch/ElasticSearchTarget.cs
@@ -94,7 +94,7 @@ namespace NLog.Targets.ElasticSearch
 
             try
             {
-                var result = _client.Bulk(payload);
+                var result = _client.Bulk<byte[]>(payload);
                 if (!result.Success)
                     InternalLogger.Error("Failed to send log messages to ElasticSearch: status={0} message=\"{1}\"", result.HttpStatusCode, result.OriginalException.Message);
             }

--- a/src/NLog.Targets.ElasticSearch/NLog.Targets.ElasticSearch.csproj
+++ b/src/NLog.Targets.ElasticSearch/NLog.Targets.ElasticSearch.csproj
@@ -33,6 +33,10 @@
     <Reference Include="Elasticsearch.Net">
       <HintPath>..\packages\Elasticsearch.Net.1.2.3\lib\Elasticsearch.Net.dll</HintPath>
     </Reference>
+    <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\packages\Newtonsoft.Json.6.0.8\lib\net40\Newtonsoft.Json.dll</HintPath>
+    </Reference>
     <Reference Include="NLog">
       <HintPath>..\packages\NLog.3.1.0.0\lib\net40\NLog.dll</HintPath>
     </Reference>

--- a/src/NLog.Targets.ElasticSearch/packages.config
+++ b/src/NLog.Targets.ElasticSearch/packages.config
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Elasticsearch.Net" version="1.2.3" targetFramework="net40" />
+  <package id="Newtonsoft.Json" version="6.0.8" targetFramework="net40" />
   <package id="NLog" version="3.1.0.0" targetFramework="net40" />
 </packages>


### PR DESCRIPTION
Elasticsearch.Net internally checks the generic parameter for Bulk method and if it is either string or byte[], it skips the deserialization which takes 70% off the CPU usage.