### PR TITLE
Flag ThrowExceptions is added to support FallbackGroup target

### DIFF
--- a/src/NLog.Targets.ElasticSearch/ElasticSearchTarget.cs
+++ b/src/NLog.Targets.ElasticSearch/ElasticSearchTarget.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections;
 using System.Collections.Generic;
 using System.Configuration;
 using System.Linq;
@@ -35,6 +34,12 @@ namespace NLog.Targets.ElasticSearch
         public IList<ElasticSearchField> Fields { get; private set; }
 
         public IElasticsearchSerializer ElasticsearchSerializer { get; set; }
+
+        /// <summary>
+        /// Defines if exception will be rethrown.
+        /// Set it to true if ElasticSearchTarget target is used within FallbackGroup target (https://github.com/NLog/NLog/wiki/FallbackGroup-target).
+        /// </summary>
+        public bool ThrowExceptions { get; set; }
 
         public ElasticSearchTarget()
         {
@@ -132,6 +137,9 @@ namespace NLog.Targets.ElasticSearch
             catch (Exception ex)
             {
                 InternalLogger.Error("Error while sending log messages to ElasticSearch: message=\"{0}\"", ex.Message);
+                //rethrow exception if required
+                if (ThrowExceptions)
+                    throw;
             }
         }
     }

--- a/src/NLog.Targets.ElasticSearch/NLog.Targets.ElasticSearch.csproj
+++ b/src/NLog.Targets.ElasticSearch/NLog.Targets.ElasticSearch.csproj
@@ -38,12 +38,6 @@
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.configuration" />
-    <Reference Include="System.Core" />
-    <Reference Include="System.Xml.Linq" />
-    <Reference Include="System.Data.DataSetExtensions" />
-    <Reference Include="Microsoft.CSharp" />
-    <Reference Include="System.Data" />
-    <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="StringExtensions.cs" />


### PR DESCRIPTION
Added ability to throw exception when bulking documents to elasticsearch in order to use ElasticSearchTarget within [FallbackGroup target](https://github.com/NLog/NLog/wiki/FallbackGroup-target).