### PR TITLE
Added check for null OriginalException during failure to send batch.

### DIFF
--- a/src/NLog.Targets.ElasticSearch/ElasticSearchTarget.cs
+++ b/src/NLog.Targets.ElasticSearch/ElasticSearchTarget.cs
@@ -109,8 +109,12 @@ namespace NLog.Targets.ElasticSearch
                 var payload = FormPayload(logEvents);
 
                 var result = _client.Bulk<byte[]>(payload);
-                if (!result.Success)
-                    InternalLogger.Error("Failed to send log messages to elasticsearch: status={0}, message=\"{1}\"", result.HttpStatusCode, result.OriginalException.Message);
+
+                if (result.Success) return;
+
+                InternalLogger.Error("Failed to send log messages to elasticsearch: status={0}, message=\"{1}\"",
+                    result.HttpStatusCode, result.OriginalException?.Message ?? "No error message. Enable Trace logging for more information.");
+                InternalLogger.Trace("Failed to send log messages to elasticsearch: result={0}", result);
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
I got an exception in the SendBatch method where the result was a failure but there was no OriginalMessage in the result. This caused an exception which was subsequently caught, but was very difficult to debug and required getting the source code.

I also added a Trace level log to show the result during a failure. I am unsure as to whether this increases the chance of leaking information but it would have helped me debug the issue. Let me know if you don't like how this logging is occurring.