### PR TITLE
Fixed: FallbackGroup and json serialization bug(temporary)

### DIFF
--- a/src/NLog.Targets.ElasticSearch/NLog.Targets.ElasticSearch.csproj
+++ b/src/NLog.Targets.ElasticSearch/NLog.Targets.ElasticSearch.csproj
@@ -38,6 +38,10 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CSharp" />
+    <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="NLog, Version=4.0.0.0, Culture=neutral, PublicKeyToken=5120e14c03d0593c, processorArchitecture=MSIL">
       <HintPath>..\packages\NLog.4.2.3\lib\net45\NLog.dll</HintPath>
       <Private>True</Private>

--- a/src/NLog.Targets.ElasticSearch/packages.config
+++ b/src/NLog.Targets.ElasticSearch/packages.config
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Elasticsearch.Net" version="2.1.0" targetFramework="net45" />
+  <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net45" />
   <package id="NLog" version="4.2.3" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
FallbackGroup issue : If bulk insert operation throws an exception, than this exception is logging but not rethrowing again. This was cousing NLog not to perform a log operation to next target when using in a FallbackGroup.

json serialization issue: this bug is on elasticsearch-net site but can be fixed temporarly. See details https://github.com/elastic/elasticsearch-net/issues/2052