### PR TITLE
Ignore self referencing loops

### DIFF
--- a/src/NLog.Targets.ElasticSearch/ElasticSearchTarget.cs
+++ b/src/NLog.Targets.ElasticSearch/ElasticSearchTarget.cs
@@ -178,7 +178,7 @@ namespace NLog.Targets.ElasticSearch
 
                 if (logEvent.Exception != null)
                 {
-                    var jsonString = JsonConvert.SerializeObject(logEvent.Exception);
+                    var jsonString = JsonConvert.SerializeObject(logEvent.Exception, new JsonSerializerSettings { ReferenceLoopHandling = ReferenceLoopHandling.Ignore });
 
                     var ex = JsonConvert.DeserializeObject<ExpandoObject>(jsonString);
 


### PR DESCRIPTION
Using `JsonConvert.Serialize` to serialize the exception could cause an exception:

> Self referencing loop detected for property 'Module' with type 'System.Reflection.RuntimeModule'. Path 'TargetSite.Module.Assembly.EntryPoint'.

This is prevented by setting `ReferenceLoopHandling` to `Ignore`.

